### PR TITLE
Fix typo, bug, cleanup and add AIToggle test

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ This is a single page application that uses React for the frontend and GraphQL f
 ## Project Structure
 
 ```
-fullstack-app/
+fullstack-ai-app/
 ├── frontend/                 # React frontend application
 │   ├── src/
 │   │   ├── components/       # React components

--- a/backend/src/index.js
+++ b/backend/src/index.js
@@ -5,9 +5,6 @@ const typeDefs = require('./schema/schema');
 const resolvers = require('./resolvers/resolvers');
 const DataAPI = require('./datasources/dataAPI');
 
-// Import uuid package for generating IDs
-const { v4: uuidv4 } = require('uuid');
-
 async function startServer() {
   // Create Express application
   const app = express();

--- a/frontend/src/components/__tests__/AIToggle.test.tsx
+++ b/frontend/src/components/__tests__/AIToggle.test.tsx
@@ -1,0 +1,27 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import AIToggle from '../AIToggle';
+import { AIProviderProvider } from '../../context/AIProviderContext';
+
+describe('AIToggle', () => {
+  test('calls onToggle with openai and huggingface when buttons clicked', async () => {
+    const user = userEvent.setup();
+    const handleToggle = jest.fn();
+
+    render(
+      <AIProviderProvider>
+        <AIToggle activeProvider="openai" onToggle={handleToggle} />
+      </AIProviderProvider>
+    );
+
+    const openAIButton = screen.getByRole('button', { name: /openai/i });
+    const hfButton = screen.getByRole('button', { name: /huggingface/i });
+
+    await user.click(hfButton);
+    expect(handleToggle).toHaveBeenCalledWith('huggingface');
+
+    await user.click(openAIButton);
+    expect(handleToggle).toHaveBeenCalledWith('openai');
+  });
+});

--- a/frontend/src/context/AIProviderContext.tsx
+++ b/frontend/src/context/AIProviderContext.tsx
@@ -12,12 +12,7 @@ type AIProviderContextType = {
 };
 
 // Create context for AI provider with proper types
-const AIProviderContext = createContext<AIProviderContextType>({
-  provider: 'openai',
-  toggleProvider: () => {},
-  isOpenAI: true,
-  isHuggingFace: false
-});
+const AIProviderContext = createContext<AIProviderContextType | undefined>(undefined);
 
 // Define props type for the provider component
 interface AIProviderProviderProps {


### PR DESCRIPTION
## Summary
- fix project folder name in README
- ensure `useAIProvider` throws outside provider
- remove unused `uuid` import
- add initial test for `AIToggle`

## Testing
- `npm test -- --watchAll=false` *(fails: react-scripts not found)*